### PR TITLE
Add file extension to `require` on index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 /* Dependencies. */
 var has = require('has');
 var xtend = require('xtend');
-var defaults = require('./github');
+var defaults = require('./github.json');
 
 /* Expose. */
 module.exports = wrapper;


### PR DESCRIPTION
The same as https://github.com/wooorm/remark/pull/264 , I got an error like as follow:

```console
ERROR in ./~/hast-util-sanitize/lib/index.js
Module not found: Error: Can't resolve './github' in '/.../node_modules/hast-util-sanitize/lib'
 @ ./~/hast-util-sanitize/lib/index.js 14:15-34
 @ ./~/hast-util-sanitize/index.js
```

Some environment such as webpack don't work correctly without extension, so I change it.
Thanks!