### PR TITLE
add "input" to allowed tag names in github sanitization schema

### DIFF
--- a/lib/github.json
+++ b/lib/github.json
@@ -100,7 +100,8 @@
     "s",
     "strike",
     "summary",
-    "details"
+    "details",
+    "input"
   ],
   "attributes": {
     "a": [

--- a/lib/github.json
+++ b/lib/github.json
@@ -127,6 +127,13 @@
     "q": [
       "cite"
     ],
+    "input": [
+      ["type", "checkbox"],
+      "disabled"
+    ],
+    "li": [
+      ["className", "task-list-item"]
+    ],
     "*": [
       "abbr",
       "accept",

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,10 +149,20 @@ function handleProperties(schema, properties, node, stack) {
   for (prop in props) {
     value = props[prop]
 
+    let accept = allowed.indexOf(prop) !== -1
+    let restricted = allowed.find(function(item) {
+      return typeof item === 'object' && item.length === 2 && item[0] === prop
+    })
+
     if (
-      allowed.indexOf(prop) === -1 &&
+      !accept &&
+      !restricted &&
       !(data(prop) && allowed.indexOf('data*') !== -1)
     ) {
+      continue
+    }
+
+    if (restricted && !complies(value, restricted[1])) {
       continue
     }
 
@@ -325,4 +335,13 @@ function allow(schema, value) {
 /* Check if `prop` is a data property. */
 function data(prop) {
   return prop.length > 4 && prop.slice(0, 4).toLowerCase() === 'data'
+}
+
+/* Check if value complies with restrictions. */
+function complies(value, restricted) {
+  if (typeof restricted === 'object' && 'length' in restricted) {
+    return restricted.indexOf(value) >= 0
+  }
+
+  return value === restricted
 }

--- a/test.js
+++ b/test.js
@@ -295,6 +295,48 @@ test('sanitize()', function(t) {
       'should ignore `undefined`'
     )
 
+    {
+      let ghMut = merge({}, gh)
+      ghMut.attributes.input = [['type', 'checkbox']]
+
+      st.deepEqual(
+        sanitize(
+          u('element', {tagName: 'input', properties: {type: 'checkbox'}}),
+          ghMut
+        ),
+        h('input', {type: 'checkbox'}),
+        'should allow values that match a single-value restriction'
+      )
+
+      st.deepEqual(
+        sanitize(
+          u('element', {tagName: 'input', properties: {type: 'text'}}),
+          ghMut
+        ),
+        h('input'),
+        "should ignore values that don't match a single-value restriction"
+      )
+
+      ghMut.attributes.input = [['type', ['checkbox', 'radio']]]
+
+      st.deepEqual(
+        sanitize(
+          u('element', {tagName: 'input', properties: {type: 'radio'}}),
+          ghMut
+        ),
+        h('input', {type: 'radio'}),
+        'should allow values that match a list restriction'
+      )
+
+      st.deepEqual(
+        sanitize(
+          u('element', {tagName: 'input', properties: {type: 'text'}}),
+          ghMut
+        ),
+        h('input'),
+        "should ignore values that don't match a list restriction"
+      )
+    }
     st.deepEqual(
       sanitize(h('div', {id: 'getElementById'})),
       h('div', {id: 'user-content-getElementById'}),


### PR DESCRIPTION
added "input" to allowed list because otherwise GFM task list checkboxes would get stripped when I used [remark-react][rr]

[rr]: https://github.com/mapbox/remark-react/