### PR TITLE
Add support for regexes to allow property values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,8 @@
  *   Possible property values
  * @typedef {string|number|boolean} PrimitivePropertyValue
  *   Possible primitive HTML attribute values
- * @typedef {string|[string, ...Array<PrimitivePropertyValue>]} AttributeValue
- * @typedef {Record<string, Array<PrimitivePropertyValue>>} AttributeMap
+ * @typedef {string|[string, ...Array<PrimitivePropertyValue|RegExp>]} AttributeValue
+ * @typedef {Record<string, Array<PrimitivePropertyValue|RegExp>>} AttributeMap
  *
  * @typedef Schema Sanitization configuration
  * @property {Record<string, Array<AttributeValue>>} [attributes]
@@ -236,7 +236,7 @@ function handleProperties(schema, properties, node, stack) {
   for (key in props) {
     if (own.call(props, key)) {
       let value = props[key]
-      /** @type {Array<PrimitivePropertyValue>} */
+      /** @type {Array<PrimitivePropertyValue|RegExp>} */
       let definition
 
       if (own.call(allowed, key)) {
@@ -281,9 +281,10 @@ function handleDoctypeName() {
 /**
  * Sanitize `tagName`.
  *
- * @type {Handler}
- * @param {unknown} tagName
+ * @param {Schema} schema
+ * @param {string} tagName
  * @param {Node} _
+ * @param {Array<string>} stack
  * @returns {string|false}
  */
 function handleTagName(schema, tagName, _, stack) {
@@ -354,7 +355,7 @@ function allow(_, value) {
  * @param {Schema} schema
  * @param {Array<unknown>} values
  * @param {string} prop
- * @param {Array<PrimitivePropertyValue>} definition
+ * @param {Array<PrimitivePropertyValue|RegExp>} definition
  * @returns {Array<string|number>}
  */
 function handlePropertyValues(schema, values, prop, definition) {
@@ -380,7 +381,7 @@ function handlePropertyValues(schema, values, prop, definition) {
  * @param {Schema} schema
  * @param {unknown} value
  * @param {string} prop
- * @param {Array<PropertyValue>} definition
+ * @param {Array<PropertyValue|RegExp>} definition
  * @returns {PropertyValue}
  */
 function handlePropertyValue(schema, value, prop, definition) {
@@ -389,7 +390,12 @@ function handlePropertyValue(schema, value, prop, definition) {
       typeof value === 'number' ||
       typeof value === 'string') &&
     safeProtocol(schema, value, prop) &&
-    (definition.length === 0 || definition.includes(value))
+    (definition.length === 0 ||
+      definition.some((allowed) =>
+        allowed && typeof allowed === 'object' && 'flags' in allowed
+          ? allowed.test(String(value))
+          : allowed === value
+      ))
   ) {
     return schema.clobberPrefix &&
       schema.clobber &&

--- a/readme.md
+++ b/readme.md
@@ -192,8 +192,9 @@ attributes: {
 
 Instead of a single string (such as `type`), which allows any [*property
 value*][value] of that [*property name*][name], it’s also possible to provide
-an array (such as `['type', 'checkbox']`), where the first entry is the
-*property name*, and all other entries allowed *property values*.
+an array (such as `['type', 'checkbox']` or `['className', /^hljs-/]`),
+where the first entry is the *property name*, and all other entries are
+*property values* allowed (or regular expressions that are tested with values).
 This is how the default GitHub schema allows only disabled checkbox inputs:
 
 ```js

--- a/test.js
+++ b/test.js
@@ -613,6 +613,30 @@ test('sanitize()', (t) => {
     t.deepEqual(
       sanitize(
         h('div', [
+          h('span', {className: 'a-one'}),
+          h('span', {className: 'a-two'}),
+          h('span', {className: 'b-one'}),
+          h('span', {className: 'b-two'}),
+          h('span', {className: 'a-one a-two b-one b-two'})
+        ]),
+        deepmerge(defaultSchema, {
+          tagNames: ['span'],
+          attributes: {span: [['className', /^a-/, 'b-one']]}
+        })
+      ),
+      h('div', [
+        h('span', {className: 'a-one'}),
+        h('span', {className: 'a-two'}),
+        h('span', {className: 'b-one'}),
+        h('span', {className: []}),
+        h('span', {className: 'a-one a-two b-one'})
+      ]),
+      'should support RegExp in the list of valid values'
+    )
+
+    t.deepEqual(
+      sanitize(
+        h('div', [
           h('select', {form: 'alpha'}),
           h('select', {form: 'bravo'}),
           h('select', {}),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Sometimes it can be unsafe to allow any values for a property while there may be so many safe values that you would need to pass a very large list.

I propose to also accept RegEx in the list of allowed property values.

<!--do not edit: pr-->
