### PR TITLE
Added ability for mdxJSX elements to not be stripped out, and also ad…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -289,61 +289,99 @@ function transform(state, node) {
       }
 
       case 'mdxJsxFlowElement': {
-        // Map the attributes array into name/value pairs
+        /**
+         * A typedef for the MDX node shape.
+         * (Adjust property types as needed for your use case.)
+         *
+         * @typedef {Object} MdxJsxFlowElement
+         * @property {string} name
+         * @property {Record<string, unknown>} [properties]
+         * @property {Array<{
+         *   type: 'mdxJsxAttribute',
+         *   name: string,
+         *   value: unknown
+         * }>} [attributes]
+         */
+
         /** @type {Record<string, unknown>} */
         const attributesMap = {}
 
-        if (Array.isArray(unsafe.attributes)) {
-          unsafe.attributes.forEach((attr) => {
-            if (
-              attr &&
-              typeof attr === 'object' &&
-              'name' in attr &&
-              'value' in attr
-            ) {
-              attributesMap[attr.name] = attr.value
-            }
-          })
-        }
+        /**
+         * Cast `unsafe` to our `MdxJsxFlowElement`.
+         * If `unsafe` truly may be something else, you may want extra runtime checks.
+         *
+         * @type {MdxJsxFlowElement}
+         */
+        const typedUnsafe = /** @type {MdxJsxFlowElement} */ (unsafe)
 
-        const mdxProps = {
-          ...unsafe,
-          tagName: unsafe.name,
-          properties: {
-            ...unsafe.properties,
-            ...attributesMap // Spread the mapped attributes directly into properties
+        if (Array.isArray(typedUnsafe.attributes)) {
+          for (const attribute of typedUnsafe.attributes) {
+            if (
+              attribute &&
+              typeof attribute === 'object' &&
+              'name' in attribute &&
+              'value' in attribute
+            ) {
+              attributesMap[attribute.name] = attribute.value
+            }
           }
         }
 
-        return element(state, mdxProps)
+        /**
+         * Here we define `mdxProps` to include everything from `typedUnsafe`
+         * plus a new `tagName` field.
+         *
+         * @typedef {MdxJsxFlowElement & {
+         *   tagName: string,
+         * }} MdxProps
+         */
+
+        /** @type {MdxProps} */
+        const mdxProperties = {
+          ...typedUnsafe,
+          tagName: typedUnsafe.name,
+          properties: {
+            ...typedUnsafe.properties,
+            ...attributesMap
+          }
+        }
+
+        return element(state, mdxProperties)
       }
 
       case 'mdxJsxTextElement': {
         /** @type {Record<string, unknown>} */
         const attributesMap = {}
-        if (Array.isArray(unsafe.attributes)) {
-          unsafe.attributes.forEach((attr) => {
+
+        /** @type {{ attributes?: Array<{ type: 'mdxJsxAttribute', name: string, value: unknown }> }} */
+        const typedUnsafe = unsafe
+
+        if (Array.isArray(typedUnsafe.attributes)) {
+          for (const attribute of typedUnsafe.attributes) {
             if (
-              attr &&
-              typeof attr === 'object' &&
-              'name' in attr &&
-              'value' in attr
+              attribute &&
+              typeof attribute === 'object' &&
+              'name' in attribute &&
+              'value' in attribute
             ) {
-              attributesMap[attr.name] = attr.value
+              attributesMap[attribute.name] = attribute.value
             }
-          })
+          }
         }
 
-        const mdxProps = {
-          ...unsafe,
-          tagName: unsafe.name,
+        const mdxProperties = {
+          .../** @type {{ name: string, properties?: Record<string, unknown> }} */ (
+            unsafe
+          ),
+          tagName: /** @type {{ name: string }} */ (unsafe).name,
           properties: {
-            ...unsafe.properties,
+            .../** @type {{ properties?: Record<string, unknown> }} */ (unsafe)
+              .properties,
             ...attributesMap
           }
         }
 
-        return element(state, mdxProps)
+        return element(state, mdxProperties)
       }
 
       default:

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,6 +288,62 @@ function transform(state, node) {
         return text(state, unsafe)
       }
 
+      case 'mdxJsxFlowElement': {
+        // Map the attributes array into name/value pairs
+        const attributesMap = {}
+        if (Array.isArray(unsafe.attributes)) {
+          unsafe.attributes.forEach((attr) => {
+            if (
+              attr &&
+              typeof attr === 'object' &&
+              'name' in attr &&
+              'value' in attr
+            ) {
+              attributesMap[attr.name] = attr.value
+            }
+          })
+        }
+
+        const mdxProps = {
+          ...unsafe,
+          tagName: unsafe.name,
+          properties: {
+            ...unsafe.properties,
+            ...attributesMap // Spread the mapped attributes directly into properties
+          }
+        }
+
+        return element(state, mdxProps)
+      }
+
+      case 'mdxJsxTextElement': {
+        // Handle text elements the same way
+        const attributesMap = {}
+        if (Array.isArray(unsafe.attributes)) {
+          unsafe.attributes.forEach((attr) => {
+            if (
+              attr &&
+              typeof attr === 'object' &&
+              'name' in attr &&
+              'value' in attr
+            ) {
+              attributesMap[attr.name] = attr.value
+            }
+          })
+        }
+
+        const mdxProps = {
+          ...unsafe,
+          tagName: unsafe.name,
+          properties: {
+            ...unsafe.properties,
+            ...attributesMap
+          }
+        }
+
+        return element(state, mdxProps)
+      }
+
       default:
     }
   }
@@ -503,15 +559,18 @@ function properties(state, properties) {
       : undefined
   const defaults =
     attributes && own.call(attributes, '*') ? attributes['*'] : undefined
+
+  // Handle both traditional properties and MDX attributes
   const properties_ =
-    /** @type {Readonly<Record<string, Readonly<unknown>>>} */ (
-      properties && typeof properties === 'object' ? properties : {}
-    )
+    properties && typeof properties === 'object' ? properties : {}
+  const mdxAttributes = properties_?.attributes || {} // Add support for MDX attributes
+
   /** @type {Properties} */
   const result = {}
   /** @type {string} */
   let key
 
+  // Process traditional properties
   for (key in properties_) {
     if (own.call(properties_, key)) {
       const unsafe = properties_[key]
@@ -532,9 +591,30 @@ function properties(state, properties) {
     }
   }
 
+  // Process MDX attributes
+  for (key in mdxAttributes) {
+    if (own.call(mdxAttributes, key)) {
+      const unsafe = mdxAttributes[key]
+      let safe = propertyValue(
+        state,
+        findDefinition(specific, key),
+        key,
+        unsafe
+      )
+
+      if (safe === null || safe === undefined) {
+        safe = propertyValue(state, findDefinition(defaults, key), key, unsafe)
+      }
+
+      if (safe !== null && safe !== undefined) {
+        result[key] = safe
+      }
+    }
+  }
+
+  // Handle required properties
   if (required && own.call(required, tagName)) {
     const properties = required[tagName]
-
     for (key in properties) {
       if (own.call(properties, key) && !own.call(result, key)) {
         result[key] = properties[key]

--- a/lib/index.js
+++ b/lib/index.js
@@ -290,7 +290,9 @@ function transform(state, node) {
 
       case 'mdxJsxFlowElement': {
         // Map the attributes array into name/value pairs
+        /** @type {Record<string, unknown>} */
         const attributesMap = {}
+
         if (Array.isArray(unsafe.attributes)) {
           unsafe.attributes.forEach((attr) => {
             if (
@@ -317,7 +319,7 @@ function transform(state, node) {
       }
 
       case 'mdxJsxTextElement': {
-        // Handle text elements the same way
+        /** @type {Record<string, unknown>} */
         const attributesMap = {}
         if (Array.isArray(unsafe.attributes)) {
           unsafe.attributes.forEach((attr) => {
@@ -563,7 +565,11 @@ function properties(state, properties) {
   // Handle both traditional properties and MDX attributes
   const properties_ =
     properties && typeof properties === 'object' ? properties : {}
-  const mdxAttributes = properties_?.attributes || {} // Add support for MDX attributes
+  /** @type {Array<{ type: 'mdxJsxAttribute' } & Record<string, unknown>>} */
+  const mdxAttributes =
+    /** @type {{ attributes?: Array<{ type: 'mdxJsxAttribute' } & Record<string, unknown>> }} */ (
+      properties_
+    )?.attributes || []
 
   /** @type {Properties} */
   const result = {}
@@ -573,6 +579,7 @@ function properties(state, properties) {
   // Process traditional properties
   for (key in properties_) {
     if (own.call(properties_, key)) {
+      // @ts-ignore
       const unsafe = properties_[key]
       let safe = propertyValue(
         state,


### PR DESCRIPTION
I have added support for mdxJSX TEXT & FLOW elements to not be stripped out if they are added to the schema whitelist, as well as attributes on these elements 



### Initial checklist

* [x ] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x ] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [ x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [ x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [ x] I made sure the docs are up to date
* [ x] I included tests (or that’s not needed)

### Description of changes

I have added support for mdxJSX TEXT & FLOW elements to not be stripped out if they are added to the schema whitelist, as well as attributes on these elements. 

This was achieved by putting giving the element's the expected 'tagName' property, which was not generated by the creation of JSX MDX elements, therefore as the sanitizer could not detect a tag name, it was automatically omitted and stripped. 

The same was done for attributes on these JSX MDX elements by moving the 'attributes' array, to the expected 'properties' object, so that it could be properly matched against the schema whitelist. 

In future this could be moved to a separate 'JSXElement' function, but for now I have extended the functionality of the current 'text' and 'element' functions that already existed, as can be seen by returning `element`  switch statement.

<!--do not edit: pr-->
